### PR TITLE
Support ArraysOfArrays v1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ ComputerAdaptiveTestingExt = "ComputerAdaptiveTesting"
 
 [compat]
 Aqua = "^0.8.2"
-ArraysOfArrays = "^0.6.2"
+ArraysOfArrays = "0.6.2, 1"
 BSplines = "^0.3.3"
 ComputerAdaptiveTesting = "^0.4.0"
 CondaPkg = "0.2"


### PR DESCRIPTION
[ArraysOfArrays.jl](https://github.com/JuliaArrays/ArraysOfArrays.jl) had a breaking release, I let Claude Code prepare dependency-updates for downstream packages, this is one of them:

This is a **compat-only change** — `ArraysOfArrays = "^0.6.2"` becomes `"0.6.2, 1"`, with no source changes. RIrtWrappers uses exactly two ArraysOfArrays constructs, the empty `VectorOfVectors{Float64}()` constructor and `push!` on it (both in `src/Mirt.jl`), and both behave identically in v1. The concrete type behind `VectorOfVectors{Float64}()` did change (it is now a `VectorOfArrays{Float64,1,0,…}` with a `SubArray` element type), but nothing here depends on that.

One caveat: the widened bound does not take effect on its own, because `FittedItemBanks` still pins ArraysOfArrays 0.6. Once https://github.com/JuliaPsychometricsBazaar/FittedItemBanks.jl/pull/8 is merged and released, this package will resolve to ArraysOfArrays 1 without further changes.

### Verification

* With this branch alone, the resolver now points only at `FittedItemBanks` as the remaining restriction — `RIrtWrappers` itself no longer appears as a blocker:

  ```
  Unsatisfiable requirements detected for package ArraysOfArrays [65a8f2f4]:
   ├─restricted to versions [0.6.2 - 0.6, 1] by RIrtWrappers [3c499bf4], leaving only versions: 0.6.2 - 1.0.2
   └─restricted by compatibility requirements with FittedItemBanks [3f797b09] to versions: 0.6.0 - 0.6.6 — no versions left
  ```

* With a locally patched `FittedItemBanks` (the change in https://github.com/JuliaPsychometricsBazaar/FittedItemBanks.jl/pull/8) `Pkg.add(name="ArraysOfArrays", version="1.0.2")` resolves and `Pkg.precompile()` completes, on Julia 1.12.
* I replayed the `src/Mirt.jl` call sites (`extract_and_convert_monopoly_params`, and the `fit_spline` conversion into `BSplineItemBank`) against both ArraysOfArrays 0.6.6 and 1.0.2 under `--depwarn=yes`: identical results, no deprecation warnings.
* I could **not** run the test suite locally — it needs an R installation with `mirt`, which I don't have here. `using RIrtWrappers` only fails at RCall's `__init__` for that reason (`No R installation was detected at RCall installation time`), so CI is the real check.

### Notes

* This repo's CompatHelper workflow is currently in state `disabled_inactivity`, so it won't have proposed this bump by itself.
* A patch release after merging would be much appreciated, so that downstream users can move to ArraysOfArrays 1 — no rush, and happy to adjust anything here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
